### PR TITLE
Add "Comment" and "Keywords" sections to starc.desktop

### DIFF
--- a/build/linux/appdir/starc.desktop
+++ b/build/linux/appdir/starc.desktop
@@ -7,4 +7,6 @@ Categories=Office;
 Exec=starc %f
 MimeType=application/x-starc;
 Name=Story Architect
-GenericName=Storywriting software
+GenericName=Storywriting Software
+Comment=Intuitive writing app with smart features and a streamlined process for film, TV and more.
+Keywords=starc screenplay screenwriting playwriting


### PR DESCRIPTION
Added "Keywords" section with keywords that enable us to search for "starc", "screenwriting", "screenplay" or "playwriting", and get Story Architect as a result. Without "starc" in the Keywords section, we wouldn't get Story Architect when searching "starc".

Added "Comment" section, providing a description of the app.