### PR TITLE
Refactor the novel export to markdown

### DIFF
--- a/src/core/ui/export/novel_export_dialog.cpp
+++ b/src/core/ui/export/novel_export_dialog.cpp
@@ -192,14 +192,12 @@ NovelExportDialog::NovelExportDialog(QWidget* _parent)
     });
     //
     auto updateParametersVisibility = [this] {
+        auto isPrintSynopsisVisible = true;
         auto isPrintInlineNotesVisible = true;
         auto isPrintReviewMarksVisible = true;
         auto exportConcreteScenesVisible = true;
         auto isWatermarkVisible = true;
         switch (d->currentFileFormat()) {
-        //
-        // PDF
-        //
         default:
         case BusinessLayer::ExportFileFormat::Pdf: {
             //
@@ -207,17 +205,12 @@ NovelExportDialog::NovelExportDialog(QWidget* _parent)
             //
             break;
         }
-        //
-        // DOCX
-        //
         case BusinessLayer::ExportFileFormat::Docx: {
             isWatermarkVisible = false;
             break;
         }
-        //
-        // Markdown
-        //
         case BusinessLayer::ExportFileFormat::Markdown: {
+            isPrintSynopsisVisible = false;
             isPrintInlineNotesVisible = false;
             isPrintReviewMarksVisible = false;
             isWatermarkVisible = false;
@@ -231,6 +224,7 @@ NovelExportDialog::NovelExportDialog(QWidget* _parent)
             exportConcreteScenesVisible = false;
         }
 
+        d->includeSynopsis->setVisible(isPrintSynopsisVisible);
         d->includeInlineNotes->setVisible(isPrintInlineNotesVisible);
         d->includeReviewMarks->setVisible(isPrintReviewMarksVisible);
         d->ornamentalBreak->setVisible(exportConcreteScenesVisible);
@@ -305,7 +299,8 @@ BusinessLayer::NovelExportOptions NovelExportDialog::exportOptions() const
     BusinessLayer::NovelExportOptions options;
     options.fileFormat = d->currentFileFormat();
     options.includeTiltePage = d->includeTitlePage->isChecked();
-    options.includeSynopsis = d->includeSynopsis->isChecked();
+    options.includeSynopsis
+        = d->includeSynopsis->isVisibleTo(this) ? d->includeSynopsis->isChecked() : false;
     options.includeText = d->includeOutline->isChecked() || d->includeNovel->isChecked();
     options.includeOutline = d->includeOutline->isChecked();
     options.includeFolders = true;

--- a/src/corelib/business_layer/export/novel/novel_markdown_exporter.cpp
+++ b/src/corelib/business_layer/export/novel/novel_markdown_exporter.cpp
@@ -5,10 +5,58 @@
 
 namespace BusinessLayer {
 
+class NovelMarkdownExporter::Implementation
+{
+public:
+    explicit Implementation();
+
+    /**
+     * @brief  Увеличить показатель вложенности глав
+     */
+    void increaseNesting();
+
+    /**
+     * @brief  Уменььшить показатель вложенности глав
+     */
+    void decreaseNesting();
+
+
+    /**
+     * @brief Глубина вложенности глав
+     */
+    mutable unsigned m_chapterNesting = 1;
+};
+
+NovelMarkdownExporter::Implementation::Implementation() = default;
+
+void NovelMarkdownExporter::Implementation::increaseNesting()
+{
+    if (m_chapterNesting > 5) {
+        m_chapterNesting = 5;
+        return;
+    } else {
+        ++m_chapterNesting;
+    }
+}
+
+void NovelMarkdownExporter::Implementation::decreaseNesting()
+{
+    if (m_chapterNesting < 2) {
+        m_chapterNesting = 2;
+        return;
+    } else {
+        --m_chapterNesting;
+    }
+}
+
+
+// ****
+
+
 NovelMarkdownExporter::NovelMarkdownExporter()
     : NovelExporter()
-    , AbstractMarkdownExporter(
-          { '\\', '`', '*', '_', '{', '}', '[', ']', '(', ')', '#', '+', '-', '.', '!', '|', '~' })
+    , AbstractMarkdownExporter({ '\\', '`', '*', '_', '#', '~', '-', '(', ')' })
+    , d(new Implementation())
 {
 }
 
@@ -38,36 +86,17 @@ bool NovelMarkdownExporter::processBlock(QString& _paragraph, const QTextBlock& 
         formatToHeading(1);
         return true;
     }
-    case TextParagraphType::ChapterHeading:
+    case TextParagraphType::ChapterHeading: {
+        d->increaseNesting();
+        formatToHeading(d->m_chapterNesting);
+        return true;
+    }
     case TextParagraphType::ChapterFooter: {
-        formatToHeading(3);
+        formatToHeading(d->m_chapterNesting);
+        d->decreaseNesting();
         return true;
     }
     case TextParagraphType::SceneHeading: {
-        formatToHeading(5);
-        return true;
-    }
-    case TextParagraphType::ChapterHeading1: {
-        formatToHeading(1);
-        return true;
-    }
-    case TextParagraphType::ChapterHeading2: {
-        formatToHeading(2);
-        return true;
-    }
-    case TextParagraphType::ChapterHeading3: {
-        formatToHeading(3);
-        return true;
-    }
-    case TextParagraphType::ChapterHeading4: {
-        formatToHeading(4);
-        return true;
-    }
-    case TextParagraphType::ChapterHeading5: {
-        formatToHeading(5);
-        return true;
-    }
-    case TextParagraphType::ChapterHeading6: {
         formatToHeading(6);
         return true;
     }
@@ -120,13 +149,7 @@ void NovelMarkdownExporter::addIndentationAtBegin(QString& _paragraph,
     auto positionInTable = [](TextParagraphType _type) {
         switch (_type) {
         case TextParagraphType::PartHeading:
-        case TextParagraphType::ChapterHeading:
-        case TextParagraphType::ChapterHeading1:
-        case TextParagraphType::ChapterHeading2:
-        case TextParagraphType::ChapterHeading3:
-        case TextParagraphType::ChapterHeading4:
-        case TextParagraphType::ChapterHeading5:
-        case TextParagraphType::ChapterHeading6: {
+        case TextParagraphType::ChapterHeading: {
             return 1;
         }
         case TextParagraphType::SceneHeading: {

--- a/src/corelib/business_layer/export/novel/novel_markdown_exporter.h
+++ b/src/corelib/business_layer/export/novel/novel_markdown_exporter.h
@@ -32,6 +32,10 @@ protected:
      */
     void addIndentationAtBegin(QString& _paragraph, TextParagraphType _previosBlockType,
                                TextParagraphType _currentBlockType) const override;
+
+private:
+    class Implementation;
+    QScopedPointer<Implementation> d;
 };
 
 } // namespace BusinessLayer


### PR DESCRIPTION
- Запретил экспорт синопсиса
- Подправил форматирование для заголовков глав (только глав, заголовки сцен и частей форматируются по-старому) 
- И ещё уменьшил количество экранируемых символов - мне кажется так будет меньше визуального шума, при этом форматирование не должно сбиваться, т.к. эти символы, которые теперь не экранируются, используются в крайне специфических случаях (например, восклицательный знак несет в себе форматный смысл только в начале абзаца и только если после него следует текст в квадратных скобках, а потом текст в круглых скобках)