### PR TITLE
Fix PDF import

### DIFF
--- a/src/corelib/business_layer/import/abstract_document_importer.cpp
+++ b/src/corelib/business_layer/import/abstract_document_importer.cpp
@@ -540,11 +540,14 @@ TextParagraphType AbstractDocumentImporter::typeForTextCursor(const QTextCursor&
             //
             // Персонаж
             // 1. В верхнем регистре
+            // 2. Предыдущий блок - не персонаж
+            // 3. Есть отступ сверху
             //
             else if ((textIsUppercase
                       || blockTextWithoutParentheses
                           == TextHelper::smartToUpper(blockTextWithoutParentheses))
-                     && _lastBlockType != TextParagraphType::Character) {
+                     && _lastBlockType != TextParagraphType::Character
+                     && blockFormat.topMargin() != 0) {
                 blockType = TextParagraphType::Character;
             }
             //


### PR DESCRIPTION
Improve the definition of the character block.

In pdf-text-extraction submodule:
- fix text position processing;
- fix right border definition;
- fix the calculation of spaces between placements