### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/src/3rd_party/hunspell/intl/vasnprintf.c
+++ b/src/3rd_party/hunspell/intl/vasnprintf.c
@@ -758,7 +758,9 @@ convert_to_decimal (mpn_t a, size_t extra_zeroes)
   size_t a_len = a.nlimbs;
   /* 0.03345 is slightly larger than log(2)/(9*log(10)).  */
   size_t c_len = 9 * ((size_t)(a_len * (GMP_LIMB_BITS * 0.03345f)) + 1);
-  char *c_ptr = (char *) malloc (xsum (c_len, extra_zeroes));
+  /* We need extra_zeroes bytes for zeroes, followed by c_len bytes for the
+     digits of a, followed by 1 byte for the terminating NUL.  */
+  char *c_ptr = (char *) malloc (xsum (xsum (extra_zeroes, c_len), 1));
   if (c_ptr != NULL)
     {
       char *d_ptr = c_ptr;


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in src/3rd_party/hunspell/intl/vasnprintf.c which was cloned from coreutils/gnulib but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2018-17942.

### Proposed Fix
Apply the same patch as the one in coreutils/gnulib to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2018-17942
https://github.com/coreutils/gnulib/commit/278b4175c9d7dd47c1a3071554aac02add3b3c35