### PR TITLE
Include OpenSSL dylibs into macOS app bundle during dmg creation

### DIFF
--- a/build/mac/create_dmg.sh
+++ b/build/mac/create_dmg.sh
@@ -8,6 +8,25 @@ find Story\ Architect.app -name "*.dSYM" -print0 | xargs -0 rm -rf
 macdeployqt Story\ Architect.app
 
 #
+# копируем OpenSSL в бандл приложения (macdeployqt не всегда подтягивает эти библиотеки)
+#
+APP_FRAMEWORKS_DIR="Story Architect.app/Contents/Frameworks"
+mkdir -p "${APP_FRAMEWORKS_DIR}"
+
+OPENSSL_PREFIX=""
+if command -v brew >/dev/null 2>&1; then
+  OPENSSL_PREFIX=$(brew --prefix openssl@3 2>/dev/null || true)
+  if [ -z "${OPENSSL_PREFIX}" ]; then
+    OPENSSL_PREFIX=$(brew --prefix openssl@1.1 2>/dev/null || true)
+  fi
+fi
+
+if [ -n "${OPENSSL_PREFIX}" ] && [ -d "${OPENSSL_PREFIX}/lib" ]; then
+  cp -f "${OPENSSL_PREFIX}"/lib/libcrypto*.dylib "${APP_FRAMEWORKS_DIR}/" 2>/dev/null || true
+  cp -f "${OPENSSL_PREFIX}"/lib/libssl*.dylib "${APP_FRAMEWORKS_DIR}/" 2>/dev/null || true
+fi
+
+#
 # подпишем app-файл
 #
 echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12

--- a/build/mac/create_dmg.sh
+++ b/build/mac/create_dmg.sh
@@ -27,6 +27,23 @@ if [ -n "${OPENSSL_PREFIX}" ] && [ -d "${OPENSSL_PREFIX}/lib" ]; then
 fi
 
 #
+# принудительно переключаем зависимости на OpenSSL из бандла, а не из системы/Homebrew
+#
+for dylib in "${APP_FRAMEWORKS_DIR}"/libcrypto*.dylib "${APP_FRAMEWORKS_DIR}"/libssl*.dylib; do
+  [ -f "${dylib}" ] || continue
+  install_name_tool -id "@executable_path/../Frameworks/$(basename "${dylib}")" "${dylib}" || true
+done
+
+for target in "Story Architect.app/Contents/MacOS/"* \
+              "Story Architect.app/Contents/Frameworks/"*.dylib; do
+  [ -f "${target}" ] || continue
+  otool -L "${target}" 2>/dev/null | awk '/lib(ssl|crypto).*\.dylib/{print $1}' | while read -r dep; do
+    [ -n "${dep}" ] || continue
+    install_name_tool -change "${dep}" "@executable_path/../Frameworks/$(basename "${dep}")" "${target}" || true
+  done
+done
+
+#
 # подпишем app-файл
 #
 echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12


### PR DESCRIPTION
### Motivation
- `macdeployqt` не всегда добавляет OpenSSL-библиотеки в `.app`-бандл, что приводит к проблемам запуска на macOS; нужно гарантировать наличие `libcrypto`/`libssl` в `Contents/Frameworks`.

### Description
- Добавлен блок в `build/mac/create_dmg.sh` после `macdeployqt` для создания папки `Story Architect.app/Contents/Frameworks` и копирования туда OpenSSL-дилок.
- Реализовано обнаружение OpenSSL через Homebrew с попыткой префикса `openssl@3` и fallback на `openssl@1.1` при отсутствии первого варианта.
- Копируются файлы `libcrypto*.dylib` и `libssl*.dylib` с подавлением ошибок, чтобы упаковка не падала, если OpenSSL/`brew` отсутствуют.

### Testing
- Содержимое и вставка блока проверялись командой `sed -n '1,260p' build/mac/create_dmg.sh` и выводом с `nl -ba build/mac/create_dmg.sh`, оба показали добавленный код успешно.
- Скрипт спроектирован так, чтобы не прерывать упаковку при отсутствии Homebrew/OpenSSL (копирование обёрнуто в условия и использует `|| true`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18226a8044832e8a9c71995b204efb)